### PR TITLE
add null check to prevent segfault

### DIFF
--- a/lin-vst-server.cpp
+++ b/lin-vst-server.cpp
@@ -1407,10 +1407,13 @@ WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR cmdline, int cmdshow)
 	}
     }
 
-   if((libname2[0] == '/') && (libname2[1] == '/'))
-   libname = strdup(&libname2[1]);
-   else
-   libname = strdup(libname2);
+
+   if(libname2 != NULL) {
+       if((libname2[0] == '/') && (libname2[1] == '/'))
+           libname = strdup(&libname2[1]);
+       else
+           libname = strdup(libname2);
+   }
 
     if (!libname || !libname[0] || !fileInfo || !fileInfo[0]) {
 	cerr << "Usage: dssi-vst-server <vstname.dll>,<tmpfilebase>" << endl;


### PR DESCRIPTION
running lin-vst-server.exe without argument would show a segfault otherwise

```
$ ./lin-vst-server.exe
DSSI VST plugin server v0.986
Copyright (c) 2004-2006 Chris Cannam
fixme:seh:dwarf_get_ptr unsupported encoding 9b
fixme:seh:dwarf_get_ptr unsupported encoding 30
fixme:seh:dwarf_get_ptr unsupported encoding 5d
wine: Unhandled page fault on read access to 0x00000000 at address 0x7f58b492622f (thread 002c), starting debugger...
fixme:dbghelp:elf_search_auxv can't find symbol in module
fixme:dbghelp:elf_search_auxv can't find symbol in module
fixme:dbghelp:elf_search_auxv can't find symbol in module
fixme:dbghelp:elf_search_auxv can't find symbol in module
fixme:dbghelp:elf_search_auxv can't find symbol in module
fixme:dbghelp:elf_search_auxv can't find symbol in module
fixme:dbghelp:elf_search_auxv can't find symbol in module
fixme:dbghelp:elf_search_auxv can't find symbol in module
fixme:dbghelp:elf_search_auxv can't find symbol in module
Unhandled exception: page fault on read access to 0x00000000 in 64-bit code (0x00007f58b492622f).
fixme:dbghelp:elf_search_auxv can't find symbol in module
Register dump:
 rip:00007f58b492622f rsp:000000000022f9b0 rbp:000000000022fbc0 eflags:00010246 (  R- --  I  Z- -P- )
 rax:0000000000000000 rbx:000000000002c05e rcx:0000000000000b40 rdx:0000000000000000
 rsi:00007f58b60a9740 rdi:00007f58b60a85e0  r8:00007f58b60a9740  r9:00007f58b5ac2b40 r10:000000000022f840
 r11:0000000000000246 r12:00007f58b666f490 r13:0000000000000000 r14:000000007b47d000 r15:00007fffff7e8000
Stack dump:
0x000000000022f9b0:  0000000000000000 000000000002c05e
0x000000000022f9c0:  0000000000010600 0000000000000000
0x000000000022f9d0:  00007f58b666f490 0000000000000000
0x000000000022f9e0:  000000000022fad0 000000007b472a7d
0x000000000022f9f0:  0000000000000000 0000000000000000
0x000000000022fa00:  ffffffffffffffff ffffffffffffffff
0x000000000022fa10:  ffffffffffffffff ffffffffffffffff
0x000000000022fa20:  5700737463656a62 754d726f46746961
0x000000000022fa30:  0000000000000000 0000000000000000
0x000000000022fa40:  ffffffffffffffff ffffffffffffffff
0x000000000022fa50:  ffffffffffffffff ffffffffffffffff
0x000000000022fa60:  ffffffffffffffff ffffffffffffffff
Backtrace:
=>0 0x00007f58b492622f WinMain+0x24b() in lin-vst-server (0x000000000022fbc0)
  1 0x00007f58b49229c5 main+0xc4() in lin-vst-server (0x0000000000000001)
  2 0x00007f58b492b741 __wine_spec_exe_entry+0x90() in lin-vst-server (0x000000000022fd60)
  3 0x000000007b47d0bf in kernel32 (+0x5d0be) (0x000000000022fe60)
  4 0x000000007bc99544 call_thread_func+0x83() in ntdll (0x00007ffc8d472460)
  5 0x000000007bc924a2 RtlRaiseException+0x7d() in ntdll (0x00007ffc8d472460)
  6 0x000000007bc5f700 in ntdll (+0x3f6ff) (0x00007ffc8d472460)
``` 