### PR TITLE
Realtime patches

### DIFF
--- a/lin-vst-server.cpp
+++ b/lin-vst-server.cpp
@@ -403,9 +403,11 @@ void RemoteVSTServer::effDoVoid(int opcode)
 #ifdef AMT
         finish = 9999;
         if (m_shm3)
-        writeInt(m_AMResponseFd, finish);
+        {
+            writeInt(m_AMResponseFd, finish);
+            getWriteSchedInfo(m_AMResponseFd);
+        }
 #endif
-
         writeInt(m_controlResponseFd, 1);
         // usleep(500000);
         terminate();
@@ -832,6 +834,7 @@ long VSTCALLBACK hostCallback(AEffect *plugin, long opcode, long index, long val
         if (alive && !exiting && remoteVSTServerInstance->m_shm3 && (bufferSize > 0))
         {
             writeInt(remoteVSTServerInstance->m_AMResponseFd, opcode);
+            getWriteSchedInfo(remoteVSTServerInstance->m_AMResponseFd);
             writeInt(remoteVSTServerInstance->m_AMResponseFd, value);
             tryRead(remoteVSTServerInstance->m_AMRequestFd, &timeInfo, sizeof(timeInfo));
             // printf("%f\n", timeInfo.sampleRate);
@@ -881,6 +884,7 @@ long VSTCALLBACK hostCallback(AEffect *plugin, long opcode, long index, long val
                 *ptr2 = eventnum;
 
                 writeInt(remoteVSTServerInstance->m_AMResponseFd, opcode);
+                getWriteSchedInfo(remoteVSTServerInstance->m_AMResponseFd);
                 writeInt(remoteVSTServerInstance->m_AMResponseFd, value);
                 ok = readInt(remoteVSTServerInstance->m_AMRequestFd);
             }
@@ -937,6 +941,7 @@ long VSTCALLBACK hostCallback(AEffect *plugin, long opcode, long index, long val
         am.delay = plugin->initialDelay;
         am.flags &= ~effFlagsCanDoubleReplacing;
         writeInt(remoteVSTServerInstance->m_AMResponseFd, opcode);
+        getWriteSchedInfo(remoteVSTServerInstance->m_AMResponseFd);
         tryWrite(remoteVSTServerInstance->m_AMResponseFd, &am, sizeof(am));
         int ok2 = readInt(remoteVSTServerInstance->m_AMRequestFd);
 /*

--- a/lin-vst-server.cpp
+++ b/lin-vst-server.cpp
@@ -39,6 +39,7 @@
 #include <time.h>
 
 #include <sched.h>
+#include <sys/mman.h>
 
 #define WIN32_LEAN_AND_MEAN
 
@@ -1197,6 +1198,8 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR cmdline, int cmds
 
     cout << "DSSI VST plugin server v" << RemotePluginVersion << endl;
     cout << "Copyright (c) 2004-2006 Chris Cannam" << endl;
+
+    mlockall(MCL_CURRENT | MCL_FUTURE);
 
     if (cmdline)
     {

--- a/lin-vst-server.cpp
+++ b/lin-vst-server.cpp
@@ -333,7 +333,8 @@ void RemoteVSTServer::EffectOpen()
     m_plugin->dispatcher(m_plugin, effGetEffectName, 0, 0, buffer, 0);
     if (debugLevel > 0)
         cerr << "dssi-vst-server[1]: plugin name is \"" << buffer << "\"" << endl;
-    if (buffer[0]) m_name = buffer;
+    if (buffer[0])
+        m_name = buffer;
 
 /*
     if (strncmp(buffer, "Guitar Rig 5", 12) == 0)
@@ -346,7 +347,8 @@ void RemoteVSTServer::EffectOpen()
     m_plugin->dispatcher(m_plugin, effGetVendorString, 0, 0, buffer, 0);
     if (debugLevel > 0)
         cerr << "dssi-vst-server[1]: vendor string is \"" << buffer << "\"" << endl;
-    if (buffer[0]) m_maker = buffer;
+    if (buffer[0])
+        m_maker = buffer;
 
 /*
     if (strncmp(buffer, "IK", 2) == 0)
@@ -922,39 +924,39 @@ long VSTCALLBACK hostCallback(AEffect *plugin, long opcode, long index, long val
             cerr << "dssi-vst-server[2]: audioMasterIOChanged requested" << endl;
 
 #ifdef AMT
-    struct amessage
-    {
-        int flags;
-        int pcount;
-        int parcount;
-        int incount;
-        int outcount;
-        int delay;
-    } am;
+        struct amessage
+        {
+            int flags;
+            int pcount;
+            int parcount;
+            int incount;
+            int outcount;
+            int delay;
+        } am;
 
-    if (alive && !exiting && remoteVSTServerInstance->m_shm3  && (bufferSize > 0))
-    {
-        am.flags = plugin->flags;
-        am.pcount = plugin->numPrograms;
-        am.parcount = plugin->numParams;
-        am.incount = plugin->numInputs;
-        am.outcount = plugin->numOutputs;
-        am.delay = plugin->initialDelay;
-        am.flags &= ~effFlagsCanDoubleReplacing;
-        writeInt(remoteVSTServerInstance->m_AMResponseFd, opcode);
-        getWriteSchedInfo(remoteVSTServerInstance->m_AMResponseFd);
-        tryWrite(remoteVSTServerInstance->m_AMResponseFd, &am, sizeof(am));
-        int ok2 = readInt(remoteVSTServerInstance->m_AMRequestFd);
+        if (alive && !exiting && remoteVSTServerInstance->m_shm3  && (bufferSize > 0))
+        {
+            am.flags = plugin->flags;
+            am.pcount = plugin->numPrograms;
+            am.parcount = plugin->numParams;
+            am.incount = plugin->numInputs;
+            am.outcount = plugin->numOutputs;
+            am.delay = plugin->initialDelay;
+            am.flags &= ~effFlagsCanDoubleReplacing;
+            writeInt(remoteVSTServerInstance->m_AMResponseFd, opcode);
+            getWriteSchedInfo(remoteVSTServerInstance->m_AMResponseFd);
+            tryWrite(remoteVSTServerInstance->m_AMResponseFd, &am, sizeof(am));
+            int ok2 = readInt(remoteVSTServerInstance->m_AMRequestFd);
 /*
-        AEffect* update = remoteVSTServerInstance->m_plugin;
-        update->flags = am.flags;
-        update->numPrograms = am.pcount;
-        update->numParams = am.parcount;
-        update->numInputs = am.incount;
-        update->numOutputs = am.outcount;
-        update->initialDelay = am.delay;
+            AEffect* update = remoteVSTServerInstance->m_plugin;
+            update->flags = am.flags;
+            update->numPrograms = am.pcount;
+            update->numParams = am.parcount;
+            update->numInputs = am.incount;
+            update->numOutputs = am.outcount;
+            update->initialDelay = am.delay;
 */
-    }
+        }
 #endif
         break;
 

--- a/rdwrops.cpp
+++ b/rdwrops.cpp
@@ -1,6 +1,5 @@
-/*
-  dssi-vst: a DSSI plugin wrapper for VST effects and instruments
-  Copyright 2004-2007 Chris Cannam
+/*  dssi-vst: a DSSI plugin wrapper for VST effects and instruments
+    Copyright 2004-2007 Chris Cannam
 */
 
 
@@ -14,174 +13,154 @@
 // #define DEBUG_RDWR 1
 
 
-extern void
-rdwr_tryWrite2(int fd, const void *buf, size_t count, const char *file, int line)
+extern void rdwr_tryWrite2(int fd, const void *buf, size_t count, const char *file, int line)
 {
- //   ssize_t w = write(fd, buf, count);
+    // ssize_t w = write(fd, buf, count);
 
-ssize_t w = 0;
-    
-     while ((w = write(fd, buf, count)) < (ssize_t)count) {
+    ssize_t w = 0;
+    while ((w = write(fd, buf, count)) < (ssize_t)count)
+    {
+        if (w < 0)
+        {
+            if (errno != EAGAIN)
+            {
+                char message[100];
+                sprintf(message, "Write failed on fd %d at %s:%d", fd, file, line);
+                perror(message);
+                throw RemotePluginClosedException();
+            }
+            w = 0;
+        }
+/*
+                char message[100];
+                sprintf(message, "Write failed on fd %d at %s:%d", fd, file, line);
+                perror(message);
+                throw RemotePluginClosedException();
+            }
 
-    if (w < 0) {
-    
-    	if (errno != EAGAIN) {
-		char message[100];
-		sprintf(message, "Write failed on fd %d at %s:%d", fd, file, line);
-		perror(message);
-		throw RemotePluginClosedException();
-	    }
-	    w = 0;
+            if (w < (ssize_t)count)
+            {
+                fprintf(stderr, "Failed to complete write on fd %d (have %d, put %d) at %s:%d\n", fd, count, w, file, line);
+                throw RemotePluginClosedException();
+        }
 
+*/
+        buf = (void *)(((char *)buf) + w);
+        count -= w;
+
+        if (count > 0)
+            usleep(20000);
     }
-/*    
-	char message[100];
-	sprintf(message, "Write failed on fd %d at %s:%d", fd, file, line);
-	perror(message);
-	throw RemotePluginClosedException();
-    }
-
-    if (w < (ssize_t)count) {
-	fprintf(stderr, "Failed to complete write on fd %d (have %d, put %d) at %s:%d\n",
-		fd, count, w, file, line);
-	throw RemotePluginClosedException();
-    }
-    
-    */
-    
-    
-    buf = (void *)(((char *)buf) + w);
-	count -= w;
-
-	if (count > 0) {
-	    usleep(20000);
-	}
-    }
-
 #ifdef DEBUG_RDWR
-    fprintf(stderr, "write succeeded at %s:%d (%d bytes)\n",
-	    file, line, w);
+    fprintf(stderr, "write succeeded at %s:%d (%d bytes)\n", file, line, w);
 #endif
 }
 
-
-extern void
-rdwr_tryRead(int fd, void *buf, size_t count, const char *file, int line)
+extern void rdwr_tryRead(int fd, void *buf, size_t count, const char *file, int line)
 {
     ssize_t r = 0;
 
-    while ((r = read(fd, buf, count)) < (ssize_t)count) {
+    while ((r = read(fd, buf, count)) < (ssize_t)count)
+    {
+        if (r == 0) // end of file
+            throw RemotePluginClosedException();
+        else if (r < 0)
+        {
+            if (errno != EAGAIN)
+            {
+                char message[100];
+                sprintf(message, "Read failed on fd %d at %s:%d", fd, file, line);
+                perror(message);
+                throw RemotePluginClosedException();
+            }
+            r = 0;
+        }
 
-	if (r == 0) {
-	    // end of file
-	    throw RemotePluginClosedException();
-	} else if (r < 0) {
-	    if (errno != EAGAIN) {
-		char message[100];
-		sprintf(message, "Read failed on fd %d at %s:%d", fd, file, line);
-		perror(message);
-		throw RemotePluginClosedException();
-	    }
-	    r = 0;
-	}
+        buf = (void *)(((char *)buf) + r);
+        count -= r;
 
-	buf = (void *)(((char *)buf) + r);
-	count -= r;
-
-	if (count > 0) {
-	    usleep(20000);
-	}
+        if (count > 0)
+                usleep(20000);
     }
-
 #ifdef DEBUG_RDWR
-    if (r >= count) {
-	fprintf(stderr, "read succeeded at %s:%d (%d bytes)\n",
-		file, line, r);
-    }
+    if (r >= count)
+        fprintf(stderr, "read succeeded at %s:%d (%d bytes)\n", file, line, r);
 #endif
 }
 
-extern void
-rdwr_tryWrite(int fd, const void *buf, size_t count, const char *file, int line)
+extern void rdwr_tryWrite(int fd, const void *buf, size_t count, const char *file, int line)
 {
     ssize_t w = write(fd, buf, count);
 
-    if (w < 0) {
-	char message[100];
-	sprintf(message, "Write failed on fd %d at %s:%d", fd, file, line);
-	perror(message);
-	throw RemotePluginClosedException();
+    if (w < 0)
+    {
+        char message[100];
+        sprintf(message, "Write failed on fd %d at %s:%d", fd, file, line);
+        perror(message);
+        throw RemotePluginClosedException();
     }
 
-    if (w < (ssize_t)count) {
-	fprintf(stderr, "Failed to complete write on fd %d (have %d, put %d) at %s:%d\n",
-		fd, count, w, file, line);
-	throw RemotePluginClosedException();
+    if (w < (ssize_t)count)
+    {
+        fprintf(stderr, "Failed to complete write on fd %d (have %d, put %d) at %s:%d\n", fd, count, w, file, line);
+        throw RemotePluginClosedException();
     }
-
 #ifdef DEBUG_RDWR
-    fprintf(stderr, "write succeeded at %s:%d (%d bytes)\n",
-	    file, line, w);
+    fprintf(stderr, "write succeeded at %s:%d (%d bytes)\n", file, line, w);
 #endif
 }
 
-extern void
-rdwr_writeOpcode(int fd, RemotePluginOpcode opcode, const char *file, int line)
+extern void rdwr_writeOpcode(int fd, RemotePluginOpcode opcode, const char *file, int line)
 {
     rdwr_tryWrite(fd, &opcode, sizeof(RemotePluginOpcode), file, line);
-}    
+}
 
-extern void
-rdwr_writeString(int fd, const std::string &str, const char *file, int line)
+extern void rdwr_writeString(int fd, const std::string &str, const char *file, int line)
 {
     int len = str.length();
     rdwr_tryWrite(fd, &len, sizeof(int), file, line);
     rdwr_tryWrite(fd, str.c_str(), len, file, line);
 }
 
-extern std::string
-rdwr_readString(int fd, const char *file, int line)
+extern std::string rdwr_readString(int fd, const char *file, int line)
 {
     int len;
     static char *buf = 0;
     static int bufLen = 0;
+
     rdwr_tryRead(fd, &len, sizeof(int), file, line);
-    if (len + 1 > bufLen) {
-	delete buf;
-	buf = new char[len + 1];
-	bufLen = len + 1;
+    if (len + 1 > bufLen)
+    {
+        delete buf;
+        buf = new char[len + 1];
+        bufLen = len + 1;
     }
+
     rdwr_tryRead(fd, buf, len, file, line);
     buf[len] = '\0';
     return std::string(buf);
 }
 
-extern void
-rdwr_writeInt(int fd, int i, const char *file, int line)
+extern void rdwr_writeInt(int fd, int i, const char *file, int line)
 {
     rdwr_tryWrite(fd, &i, sizeof(int), file, line);
 }
 
-extern int
-rdwr_readInt(int fd, const char *file, int line)
+extern int rdwr_readInt(int fd, const char *file, int line)
 {
     int i = 0;
     rdwr_tryRead(fd, &i, sizeof(int), file, line);
     return i;
 }
 
-extern void
-rdwr_writeFloat(int fd, float f, const char *file, int line)
+extern void rdwr_writeFloat(int fd, float f, const char *file, int line)
 {
     rdwr_tryWrite(fd, &f, sizeof(float), file, line);
 }
 
-extern float
-rdwr_readFloat(int fd, const char *file, int line)
+extern float rdwr_readFloat(int fd, const char *file, int line)
 {
     float f = 0;
     rdwr_tryRead(fd, &f, sizeof(float), file, line);
     return f;
 }
-
-

--- a/rdwrops.cpp
+++ b/rdwrops.cpp
@@ -164,3 +164,22 @@ extern float rdwr_readFloat(int fd, const char *file, int line)
     rdwr_tryRead(fd, &f, sizeof(float), file, line);
     return f;
 }
+
+extern void rdwr_getWriteSchedInfo(int fd, const char *file, int line)
+{
+    int policy = -1;
+    sched_param param;
+    param.sched_priority = -1;
+    pthread_getschedparam(pthread_self(), &policy, &param);
+    writeInt(fd, policy);
+    writeInt(fd, param.sched_priority);
+}
+
+extern void rdwr_readSetSchedInfo(int fd, const char *file, int line)
+{
+    int policy = readInt(fd);
+    sched_param param;
+    param.sched_priority = readInt(fd);
+    if (policy != -1)
+        pthread_setschedparam(pthread_self(), policy, &param);
+}

--- a/rdwrops.h
+++ b/rdwrops.h
@@ -6,6 +6,7 @@
 #ifndef _RD_WR_OPS_H_
 
 #include <string>
+#include <sched.h>
 #include "remoteplugin.h"
 
 extern void rdwr_tryWrite2(int fd, const void *buf, size_t count, const char *file, int line);
@@ -18,6 +19,8 @@ extern void rdwr_writeInt(int fd, int i, const char *file, int line);
 extern int rdwr_readInt(int fd, const char *file, int line);
 extern void rdwr_writeFloat(int fd, float f, const char *file, int line);
 extern float rdwr_readFloat(int fd, const char *file, int line);
+extern void rdwr_getWriteSchedInfo(int Fd, const char *file, int line);
+extern void rdwr_readSetSchedInfo(int Fd, const char *file, int line);
 
 #define tryWrite2(a, b, c) rdwr_tryWrite2(a, b, c, __FILE__, __LINE__)
 #define tryRead(a, b, c) rdwr_tryRead(a, b, c, __FILE__, __LINE__)
@@ -29,5 +32,7 @@ extern float rdwr_readFloat(int fd, const char *file, int line);
 #define readInt(a) rdwr_readInt(a, __FILE__, __LINE__)
 #define writeFloat(a, b) rdwr_writeFloat(a, b, __FILE__, __LINE__)
 #define readFloat(a) rdwr_readFloat(a, __FILE__, __LINE__)
+#define getWriteSchedInfo(a) rdwr_getWriteSchedInfo(a, __FILE__, __LINE__)
+#define readSetSchedInfo(a) rdwr_readSetSchedInfo(a, __FILE__, __LINE__)
 
 #endif

--- a/remotepluginclient.cpp
+++ b/remotepluginclient.cpp
@@ -104,6 +104,7 @@ void* RemotePluginClient::AMThread()
 */
                 opcode = -1;
                 tryRead(m_AMResponseFd, &opcode, sizeof(int));
+                readSetSchedInfo(m_AMResponseFd);
 
                 if (opcode == finishthread)
                     break;
@@ -795,24 +796,28 @@ float   RemotePluginClient::getVersion()
 {
     //FIXME!!! client code needs to be testing this
     writeOpcode(m_parRequestFd, RemotePluginGetVersion);
+    getWriteSchedInfo(m_parRequestFd);
     return readFloat(m_parResponseFd);
 }
 
 int RemotePluginClient::getUID()
 {
     writeOpcode(m_parRequestFd, RemotePluginUniqueID);
+    getWriteSchedInfo(m_parRequestFd);
     return readInt(m_parResponseFd);
 }
 
 std::string RemotePluginClient::getName()
 {
     writeOpcode(m_parRequestFd, RemotePluginGetName);
+    getWriteSchedInfo(m_parRequestFd);
     return readString(m_parResponseFd);
 }
 
 std::string RemotePluginClient::getMaker()
 {
     writeOpcode(m_parRequestFd, RemotePluginGetMaker);
+    getWriteSchedInfo(m_parRequestFd);
     return readString(m_parResponseFd);
 }
 
@@ -829,6 +834,7 @@ void RemotePluginClient::setBufferSize(int s)
 
     m_bufferSize = s;
     writeOpcode(m_parRequestFd, RemotePluginSetBufferSize);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, s);
     int ok = readInt(m_parResponseFd);
 }
@@ -836,6 +842,7 @@ void RemotePluginClient::setBufferSize(int s)
 void RemotePluginClient::setSampleRate(int s)
 {
     writeOpcode(m_parRequestFd, RemotePluginSetSampleRate);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, s);
     int ok = readInt(m_parResponseFd);
 }
@@ -843,6 +850,7 @@ void RemotePluginClient::setSampleRate(int s)
 void RemotePluginClient::reset()
 {
     writeOpcode(m_parRequestFd, RemotePluginReset);
+    getWriteSchedInfo(m_parRequestFd);
     if (m_shmSize > 0)
     {
         memset(m_shm, 0, m_shmSize);
@@ -855,11 +863,13 @@ void RemotePluginClient::reset()
 void RemotePluginClient::terminate()
 {
     writeOpcode(m_parRequestFd, RemotePluginTerminate);
+    getWriteSchedInfo(m_parRequestFd);
 }
 
 int RemotePluginClient::getEffInt(int opcode)
 {
     writeOpcode(m_parRequestFd, RemotePluginGetEffInt);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, opcode);
     return readInt(m_parResponseFd);
 }
@@ -867,6 +877,7 @@ int RemotePluginClient::getEffInt(int opcode)
 void RemotePluginClient::getEffString(int opcode, int index, char *ptr, int len)
 {
     writeOpcode(m_parRequestFd, RemotePluginGetEffString);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, opcode);
     writeInt(m_parRequestFd, index);
     strncpy(ptr, readString(m_parResponseFd).c_str(), len);
@@ -876,12 +887,14 @@ void RemotePluginClient::getEffString(int opcode, int index, char *ptr, int len)
 int RemotePluginClient::getFlags()
 {
     writeOpcode(m_parRequestFd, RemotePluginGetFlags);
+    getWriteSchedInfo(m_parRequestFd);
     return readInt(m_parResponseFd);
 }
 
 int RemotePluginClient::getinitialDelay()
 {
     writeOpcode(m_parRequestFd, RemotePluginGetinitialDelay);
+    getWriteSchedInfo(m_parRequestFd);
     return readInt(m_parResponseFd);
 }
 
@@ -891,6 +904,7 @@ int RemotePluginClient::getInputCount()
     // m_numInputs = readInt(m_processResponseFd);
 
     writeOpcode(m_parRequestFd, RemotePluginGetInputCount);
+    getWriteSchedInfo(m_parRequestFd);
     m_numInputs = readInt(m_parResponseFd);
     return m_numInputs;
 }
@@ -901,6 +915,7 @@ int RemotePluginClient::getOutputCount()
     // m_numOutputs = readInt(m_processResponseFd);
 
     writeOpcode(m_parRequestFd, RemotePluginGetOutputCount);
+    getWriteSchedInfo(m_parRequestFd);
     m_numOutputs = readInt(m_parResponseFd);
     return m_numOutputs;
 }
@@ -908,12 +923,14 @@ int RemotePluginClient::getOutputCount()
 int RemotePluginClient::getParameterCount()
 {
     writeOpcode(m_parRequestFd, RemotePluginGetParameterCount);
+    getWriteSchedInfo(m_parRequestFd);
     return readInt(m_parResponseFd);
 }
 
 std::string RemotePluginClient::getParameterName(int p)
 {
     writeOpcode(m_parRequestFd, RemotePluginGetParameterName);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, p);
     return readString(m_parResponseFd);
 }
@@ -921,6 +938,7 @@ std::string RemotePluginClient::getParameterName(int p)
 void RemotePluginClient::setParameter(int p, float v)
 {
     writeOpcode(m_parRequestFd, RemotePluginSetParameter);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, p);
     writeFloat(m_parRequestFd, v);
     // wait for a response
@@ -930,6 +948,7 @@ void RemotePluginClient::setParameter(int p, float v)
 float RemotePluginClient::getParameter(int p)
 {
     writeOpcode(m_parRequestFd, RemotePluginGetParameter);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, p);
     return readFloat(m_parResponseFd);
 }
@@ -937,6 +956,7 @@ float RemotePluginClient::getParameter(int p)
 float RemotePluginClient::getParameterDefault(int p)
 {
     writeOpcode(m_parRequestFd, RemotePluginGetParameterDefault);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, p);
     return readFloat(m_parResponseFd);
 }
@@ -944,6 +964,7 @@ float RemotePluginClient::getParameterDefault(int p)
 void RemotePluginClient::getParameters(int p0, int pn, float *v)
 {
     writeOpcode(m_parRequestFd, RemotePluginGetParameters);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, p0);
     writeInt(m_parRequestFd, pn);
     tryRead(m_parResponseFd, v, (pn - p0 + 1) * sizeof(float));
@@ -952,12 +973,14 @@ void RemotePluginClient::getParameters(int p0, int pn, float *v)
 int RemotePluginClient::getProgramCount()
 {
     writeOpcode(m_parRequestFd, RemotePluginGetProgramCount);
+    getWriteSchedInfo(m_parRequestFd);
     return readInt(m_parResponseFd);
 }
 
 std::string RemotePluginClient::getProgramNameIndexed(int n)
 {
     writeOpcode(m_parRequestFd, RemotePluginGetProgramNameIndexed);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, n);
     return readString(m_parResponseFd);
 }
@@ -965,12 +988,14 @@ std::string RemotePluginClient::getProgramNameIndexed(int n)
 std::string RemotePluginClient::getProgramName()
 {
     writeOpcode(m_parRequestFd, RemotePluginGetProgramName);
+    getWriteSchedInfo(m_parRequestFd);
     return readString(m_parResponseFd);
 }
 
 void RemotePluginClient::setCurrentProgram(int n)
 {
     writeOpcode(m_parRequestFd, RemotePluginSetCurrentProgram);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, n);
     int ok = readInt(m_parResponseFd);
 }
@@ -997,6 +1022,7 @@ void RemotePluginClient::process(float **inputs, float **outputs, int sampleFram
         memcpy(m_shm + i * blocksz, inputs[i], sampleFrames*sizeof(float));
 
     writeOpcode(m_processFd, RemotePluginProcess);
+    getWriteSchedInfo(m_processFd);
     writeInt(m_processFd, sampleFrames);
 
     int resp;
@@ -1044,6 +1070,7 @@ int RemotePluginClient::processVstEvents(VstEvents *evnts)
     ret = evnts->numEvents;
 
     writeOpcode(m_processFd, RemotePluginProcessEvents);
+    getWriteSchedInfo(m_processFd);
     int ok = readInt(m_processResponseFd);
     return ret;
 }
@@ -1051,12 +1078,14 @@ int RemotePluginClient::processVstEvents(VstEvents *evnts)
 void RemotePluginClient::setDebugLevel(RemotePluginDebugLevel level)
 {
     writeOpcode(m_parRequestFd, RemotePluginSetDebugLevel);
+    getWriteSchedInfo(m_parRequestFd);
     tryWrite(m_parRequestFd, &level, sizeof(RemotePluginDebugLevel));
 }
 
 bool RemotePluginClient::warn(std::string str)
 {
     writeOpcode(m_parRequestFd, RemotePluginWarn);
+    getWriteSchedInfo(m_parRequestFd);
     writeString(m_parRequestFd, str);
     bool b;
     tryRead(m_parResponseFd, &b, sizeof(bool));
@@ -1108,6 +1137,7 @@ int RemotePluginClient::getChunk(void **ptr, int bank_prg)
 {
     static void *chunk_ptr = 0;
     writeOpcode(m_parRequestFd, RemotePluginGetChunk);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, bank_prg);
     int sz = readInt(m_parResponseFd);
 
@@ -1123,6 +1153,7 @@ int RemotePluginClient::getChunk(void **ptr, int bank_prg)
 int RemotePluginClient::setChunk(void *ptr, int sz, int bank_prg)
 {
     writeOpcode(m_parRequestFd, RemotePluginSetChunk);
+    getWriteSchedInfo(m_parRequestFd);
     writeInt(m_parRequestFd, sz);
     writeInt(m_parRequestFd, bank_prg);
     tryWrite2(m_parRequestFd, ptr, sz);
@@ -1141,6 +1172,7 @@ int RemotePluginClient::canBeAutomated(int param)
 int RemotePluginClient::getProgram()
 {
     writeOpcode(m_parRequestFd, RemotePluginGetProgram);
+    getWriteSchedInfo(m_parRequestFd);
     return readInt(m_parResponseFd);
 }
 
@@ -1149,3 +1181,4 @@ int RemotePluginClient::EffectOpen()
     writeOpcode(m_controlRequestFd, RemotePluginEffectOpen);
     return readInt(m_controlResponseFd);
 }
+

--- a/remotepluginserver.cpp
+++ b/remotepluginserver.cpp
@@ -585,6 +585,8 @@ void RemotePluginServer::dispatchProcessEvents()
 */
     // std::cerr << "read process opcode: " << opcode << std::endl;
 
+    readSetSchedInfo(m_processFd);
+
     switch (opcode)
     {
     case RemotePluginProcess:
@@ -661,8 +663,6 @@ void RemotePluginServer::dispatchProcessEvents()
     // std::cerr << "dispatched process event\n";
 }
 
-
-
 void RemotePluginServer::dispatchParEvents()
 {
     RemotePluginOpcode  opcode = RemotePluginNoOpcode;
@@ -670,6 +670,8 @@ void RemotePluginServer::dispatchParEvents()
 
     tryRead(m_parRequestFd, &opcode, sizeof(RemotePluginOpcode));
     // std::cerr << "control opcoded " << opcode << std::endl;
+
+    readSetSchedInfo(m_parRequestFd);
 
     switch (opcode)
     {

--- a/remotepluginserver.cpp
+++ b/remotepluginserver.cpp
@@ -449,7 +449,7 @@ void RemotePluginServer::dispatchControl(int timeout)
     else if (pfd.revents)
     {
         if (m_threadsfinish == 1)
-        return;
+            return;
         throw RemotePluginClosedException();
     }
 /*
@@ -463,7 +463,7 @@ void RemotePluginServer::dispatchControl(int timeout)
     if ((n = select(m_controlRequestFd+1, &rfds, &ofds, &ofds, &timeo)) == -1)
     {
         if (m_threadsfinish == 1)
-        return;
+            return;
         throw RemotePluginClosedException();
     }
     if (n == 1)
@@ -496,7 +496,7 @@ void RemotePluginServer::dispatchPar(int timeout)
     else if (pfd.revents)
     {
         if (m_threadsfinish == 1)
-        return;
+            return;
         throw RemotePluginClosedException();
     }
 /*
@@ -542,7 +542,7 @@ void RemotePluginServer::dispatchProcess(int timeout)
     else if (pfd.revents)
     {
         if (m_threadsfinish == 1)
-        return;
+            return;
         throw RemotePluginClosedException();
     }
 /*


### PR DESCRIPTION
This is a preliminary attempt to get the priority of the calling thread, communicate that to the remote, and finally make sure that the thread on the remote uses the same scheduling class and priority as the calling thread did.  Also make sure that the windows side remains in ram and can't be discarded or swapped to disk.  And again some indentation fixes :)

This seems to help a lot, but I don't think it's the entire solution :S  We'll have to keep digging in it :)

I'm not sure about placing the implementation in rdwrops, but seemed the easiest.  I guess it's up to you to decide if you like that or not.