### PR TITLE
Fix GetProgramNameIndexed to return names and return value

### DIFF
--- a/lin-vst-server.cpp
+++ b/lin-vst-server.cpp
@@ -99,7 +99,7 @@ public:
     virtual void        getParameters(int, int, float *);
 
     virtual int         getProgramCount() { if(m_plugin) return m_plugin->numPrograms; }
-    virtual std::string getProgramNameIndexed(int);
+    virtual int         getProgramNameIndexed(int, char *name);
     virtual std::string getProgramName();
 #ifdef WAVES
     virtual int         getShellName(char *name);
@@ -774,16 +774,18 @@ void RemoteVSTServer::getParameters(int p0, int pn, float *v)
         v[i - p0] = m_plugin->getParameter(m_plugin, i);
 }
 
-std::string RemoteVSTServer::getProgramNameIndexed(int p)
+int RemoteVSTServer::getProgramNameIndexed(int p, char *name)
 {
     if (debugLevel > 1)
         cerr << "dssi-vst-server[2]: getProgramName(" << p << ")" << endl;
 
-    char name[512];
-    memset(name, 0, sizeof(name));
+    int retval = 0;
+    char nameret[512];
+    memset(nameret, 0, sizeof(nameret));
 
-    m_plugin->dispatcher(m_plugin, effGetProgramNameIndexed, p, 0, name, 0);
-    return name;
+    retval = m_plugin->dispatcher(m_plugin, effGetProgramNameIndexed, p, 0, nameret, 0);
+    strcpy(name, nameret); 
+    return retval;
 }
 
 std::string

--- a/linvst.cpp
+++ b/linvst.cpp
@@ -609,7 +609,7 @@ VstIntPtr dispatcher(AEffect* effect, VstInt32 opcode, VstInt32 index, VstIntPtr
         break;
 
     case effGetProgramNameIndexed:
-        strncpy((char *) ptr, plugin->getProgramNameIndexed(index).c_str(), kVstMaxProgNameLen);
+        v = plugin->getProgramNameIndexed(index, (char *) ptr);
         break;
 
     case effGetProgramName:

--- a/remotepluginclient.cpp
+++ b/remotepluginclient.cpp
@@ -1347,13 +1347,14 @@ int RemotePluginClient::getProgramCount()
     return readInt(&m_shm[FIXED_SHM_SIZE]);
 }
 
-std::string RemotePluginClient::getProgramNameIndexed(int n)
+int RemotePluginClient::getProgramNameIndexed(int n, char *ptr)
 {
     writeOpcodering(&m_shmControl5->ringBuffer, RemotePluginGetProgramNameIndexed);
     writeIntring(&m_shmControl5->ringBuffer, n);
     commitWrite(&m_shmControl5->ringBuffer);
     waitForServer5();  
-    return readString(&m_shm[FIXED_SHM_SIZE]);
+    strcpy(ptr, readString(&m_shm[FIXED_SHM_SIZE]).c_str());
+    return readInt(&m_shm[FIXED_SHM_SIZE + 512]);
 }
 
 std::string RemotePluginClient::getProgramName()

--- a/remotepluginclient.h
+++ b/remotepluginclient.h
@@ -84,7 +84,7 @@ public:
     void                getParameters(int, int, float *);
 
     int                 getProgramCount();
-    std::string         getProgramNameIndexed(int);
+    int                 getProgramNameIndexed(int, char *ptr);
     std::string         getProgramName();
     void                setCurrentProgram(int);
 

--- a/remotepluginserver.cpp
+++ b/remotepluginserver.cpp
@@ -1245,8 +1245,13 @@ void RemotePluginServer::dispatchParEvents()
         break;
 
     case RemotePluginGetProgramNameIndexed:
-        writeString(&m_shm[FIXED_SHM_SIZE], getProgramNameIndexed(readIntring(&m_shmControl5->ringBuffer)));
+    {
+        char name[512];
+        int retvalprogramname = getProgramNameIndexed(readIntring(&m_shmControl5->ringBuffer), name);
+        writeInt(&m_shm[FIXED_SHM_SIZE + 512], retvalprogramname);
+        writeString(&m_shm[FIXED_SHM_SIZE], name);
         break;
+    }
 
     case RemotePluginGetProgramName:
         writeString(&m_shm[FIXED_SHM_SIZE], getProgramName());

--- a/remotepluginserver.h
+++ b/remotepluginserver.h
@@ -68,7 +68,7 @@ public:
     virtual int             getShellName(char *name)                { return 0; }
 #endif
     virtual int             getProgramCount()                       { return 0; }
-    virtual std::string     getProgramNameIndexed(int)              { return ""; }
+    virtual int             getProgramNameIndexed(int, char *name)  { return 0; }
     virtual std::string     getProgramName()                        { return ""; }
     virtual void            setCurrentProgram(int)                  { return; }
 


### PR DESCRIPTION
Using Ardour preset dropdowns for LinVst bridged Windows VST2 plugins were showing "Preset" + number instead of the factory preset names as included in the Windows VST2 dll.
Problem:
GetProgramNameIndexed was returning the Preset name to the Linux host (Ardour), while GetProgramNameIndexed should return the name via the passed (char *) pointer and an int status (1 = success).
Solution:
Change GetProgramNameIndexed to pass the preset name via the (char *) pointer and pass the return value from the Windows dll to the Linux host (Ardour).