### PR TITLE
Fix compilation in Arch-based systems

### DIFF
--- a/deb-packages/32bitonly/exelinvst/CMakeLists.txt
+++ b/deb-packages/32bitonly/exelinvst/CMakeLists.txt
@@ -35,6 +35,7 @@ find_path( WIN_INCLUDE windows.h
   /usr/include/wine-development/windows
   /usr/include/wine-development/wine/windows
   /usr/include/wine/wine/windows
+  /usr/include/wine/windows
   /opt/wine-stable/include/wine/windows
   /opt/wine-devel/include/wine/windows
   /opt/wine-staging/include/wine/windows

--- a/deb-packages/64bits-32bits/exelinvst/CMakeLists.txt
+++ b/deb-packages/64bits-32bits/exelinvst/CMakeLists.txt
@@ -42,6 +42,7 @@ find_path( WIN_INCLUDE windows.h
   /usr/include/wine-development/windows
   /usr/include/wine-development/wine/windows
   /usr/include/wine/wine/windows
+  /usr/include/wine/windows
   /opt/wine-stable/include/wine/windows
   /opt/wine-devel/include/wine/windows
   /opt/wine-staging/include/wine/windows

--- a/deb-packages/64bitsonly/exelinvst/CMakeLists.txt
+++ b/deb-packages/64bitsonly/exelinvst/CMakeLists.txt
@@ -42,6 +42,7 @@ find_path( WIN_INCLUDE windows.h
   /usr/include/wine-development/windows
   /usr/include/wine-development/wine/windows
   /usr/include/wine/wine/windows
+  /usr/include/wine/windows
   /opt/wine-stable/include/wine/windows
   /opt/wine-devel/include/wine/windows
   /opt/wine-staging/include/wine/windows


### PR DESCRIPTION
First, congrats on this project. LinVst helped me to use Windows VSTs on my Linux machines when other solutions failed.

This PR will fix compilation for Arch-based systems. This fix will work for both `wine` and `wine-staging` package since the `windows.h` header path is the same. It should not interfere with other OSes.