### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *~
+*.so
+*.o
+*.exe
+
+compile_commands.json


### PR DESCRIPTION
I have added some extensions to gitignore file. The rationale behind this is to avoid having a dirty directory after compilation or adding compiled files by mistake.

I have added also `compile_commands.json` that is usually used by Clang, some build systems and some completion/linter engines (clangd and others).

Changes:
* Ignore extensions: `.so`, `.exe`, `.o`
* Ignore `compile_commands.json` used by some build systems.