### PR TITLE
[WIP] Refactor macros

### DIFF
--- a/paths.cpp
+++ b/paths.cpp
@@ -15,6 +15,7 @@ vst: a DSSI plugin wrapper for VST effects and instruments
 #include <string.h>
 
 
+
 std::vector<std::string>
 Paths::getPath(std::string envVar, std::string deflt, std::string defltHomeRelPath)
 {
@@ -39,11 +40,12 @@ Paths::getPath(std::string envVar, std::string deflt, std::string defltHomeRelPa
 	pathList.push_back(path.substr(index, newindex - index));
 	index = newindex + 1;
     }
-    
+
     pathList.push_back(path.substr(index));
 
     return pathList;
 }
+
 
 // Behaves like mkstemp, but for shared memory.
 int shm_mkstemp(char *fileBase)
@@ -71,8 +73,41 @@ int shm_mkstemp(char *fileBase)
         int fd = shm_open(fileBase, O_RDWR | O_CREAT | O_EXCL, 0660);
         if (fd >= 0) {
             return fd;
-        } else if (errno != EEXIST) { 
+        } else if (errno != EEXIST) {
             return -1;
         }
     }
+}
+
+
+std::string
+getBinaryPath(std::string basename, std::string suffix, std::string ext)
+{
+    std::string parentPath = "/usr/bin";
+
+#ifdef EMBED
+    suffix += "st";
+#endif
+
+    std::string fullPath = parentPath + "/" + basename + suffix + ext;
+    return fullPath;
+}
+
+std::vector<std::string>
+getCombinedBinaryPaths(std::vector<std::string> basenames,
+                       std::vector<std::string> suffixes,
+                       std::vector<std::string> extensions)
+{
+  std::vector<std::string> resultPaths;
+
+  for (auto basename : basenames) {
+    for (auto suffix : suffixes) {
+      for (auto ext : extensions) {
+        auto fullPath = getBinaryPath(basename, suffix, ext);
+        resultPaths.push_back(fullPath);
+      }
+    }
+  }
+
+  return resultPaths;
 }

--- a/paths.h
+++ b/paths.h
@@ -15,8 +15,37 @@ public:
     std::vector<std::string> getPath(std::string envVar,
 					    std::string deflt,
 					    std::string defltHomeRelPath);
+
 };
 
 int shm_mkstemp(char *fileBase);
+
+
+/**
+ * This function provided the full path to a binary provided the basename of
+ * the file and the extensions. It may consider enviromental variables and
+ * if some enabled macros.
+ *
+ * \param basename base name of the file
+ * \param suffix file suffix before extension
+ * \param ext extension of the file
+ * \return string containing a complete path to the file.
+ */
+std::string getBinaryPath(std::string basename, std::string suffix,
+                          std::string ext);
+
+/**
+ * Generate a list of full paths of the binaries combining all the elements in
+ * the input lists.
+ *
+ * \param basenames list of base name of the file
+ * \param suffixes list of file suffix before extension
+ * \param extensions list of extensions of the file
+ * \return string containing a complete path to the file.
+ */
+std::vector<std::string>
+getCombinedBinaryPaths(std::vector<std::string> basenames,
+                       std::vector<std::string> suffixes,
+                       std::vector<std::string> extensions);
 
 #endif

--- a/remotevstclient.cpp
+++ b/remotevstclient.cpp
@@ -47,6 +47,8 @@
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
 
+
+
 void errwin(std::string dllname)
 {
 Window window = 0;
@@ -210,200 +212,42 @@ RemoteVSTClient::RemoteVSTClient(audioMasterCallback theMaster) : RemotePluginCl
     mfile.close();
 #endif
 
-#ifndef VST32     
+    // Define basename and suffix
+    std::string basename = "lin-vst-server";
+    std::string suffix = "";
+
+#ifdef VST32
+    suffix += "32lx";
+#else
 #ifdef VST6432
-#ifdef TRACKTIONWM 
-    if (dlltype == 2)
-    {
-#ifdef EMBED    
-    LinVstName = "/usr/bin/lin-vst-servertrack32.exe";
-#else
-    LinVstName = "/usr/bin/lin-vst-servertrack32st.exe";
-#endif    
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
+    if (dlltype == 2) {
+        suffix += "32";
     }
-#ifdef EMBED     
-    LinVstName = "/usr/bin/lin-vst-servertrack32.exe.so";
-#else
-    LinVstName = "/usr/bin/lin-vst-servertrack32st.exe.so";
-#endif    
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    }
-    }
-    else
-    {
-#ifdef EMBED 
-    LinVstName = "/usr/bin/lin-vst-servertrack.exe";
-#else
-    LinVstName = "/usr/bin/lin-vst-servertrackst.exe";
-#endif        
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    }
-#ifdef EMBED     
-    LinVstName = "/usr/bin/lin-vst-servertrack.exe.so";
-#else
-    LinVstName = "/usr/bin/lin-vst-servertrackst.exe.so";
-#endif    
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    }
-    }   
-#else
-    if (dlltype == 2)
-    {
-#ifdef EMBED 
-    LinVstName = "/usr/bin/lin-vst-server32.exe";
-#else
-    LinVstName = "/usr/bin/lin-vst-server32st.exe";
-#endif
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    }
-#ifdef EMBED 
-    LinVstName = "/usr/bin/lin-vst-server32.exe.so";
-#else
-    LinVstName = "/usr/bin/lin-vst-server32st.exe.so";
-#endif    
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    }
-    }
-    else
-    {
-#ifdef EMBED  
-    LinVstName = "/usr/bin/lin-vst-server.exe";
-#else
-    LinVstName = "/usr/bin/lin-vst-serverst.exe";
-#endif    
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    }
-#ifdef EMBED     
-    LinVstName = "/usr/bin/lin-vst-server.exe.so";
-#else
-    LinVstName = "/usr/bin/lin-vst-serverst.exe.so";
-#endif    
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    } 
-    }       
-#endif
-#else
-#ifdef TRACKTIONWM 
-#ifdef EMBED 
-    LinVstName = "/usr/bin/lin-vst-servertrack.exe";
-#else
-    LinVstName = "/usr/bin/lin-vst-servertrackst.exe";
-#endif        
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    }
-#ifdef EMBED     
-    LinVstName = "/usr/bin/lin-vst-servertrack.exe.so";
-#else
-    LinVstName = "/usr/bin/lin-vst-servertrackst.exe.so";
-#endif    
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    }
-#else
-#ifdef EMBED  
-    LinVstName = "/usr/bin/lin-vst-server.exe";
-#else
-    LinVstName = "/usr/bin/lin-vst-serverst.exe";
-#endif    
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    }
-#ifdef EMBED     
-    LinVstName = "/usr/bin/lin-vst-server.exe.so";
-#else
-    LinVstName = "/usr/bin/lin-vst-serverst.exe.so";
-#endif    
-    test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
-    }
+// Tracktion only considered for VST64_32
+#ifdef TRACKTIONWM
+    basename += "track";
 #endif
 #endif
 #endif
 
-#ifdef VST32
-#ifdef EMBED 
-    LinVstName = "/usr/bin/lin-vst-server32lx.exe";
-#else
-    LinVstName = "/usr/bin/lin-vst-server32lxst.exe";
-#endif
+    std::string vstExePath = getBinaryPath(basename, suffix, ".exe");
+    std::string vstSoPath = getBinaryPath(basename, suffix, ".exe.so");
+
+    LinVstName = vstExePath;
     test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
+    if (!test) {
+      m_runok = 1;
+      cleanup();
+      return;
     }
-#ifdef EMBED     
-    LinVstName = "/usr/bin/lin-vst-server32lx.exe.so";
-#else
-    LinVstName = "/usr/bin/lin-vst-server32lxst.exe.so";
-#endif    
+
+    LinVstName = vstSoPath;
     test = std::ifstream(LinVstName.c_str()).good();
-    if (!test)
-    {
-    m_runok = 1;
-    cleanup();
-    return;
+    if (!test) {
+      m_runok = 1;
+      cleanup();
+      return;
     }
-#endif
 
     hit2[0] = '\0';
 
@@ -443,102 +287,12 @@ RemoteVSTClient::RemoteVSTClient(audioMasterCallback theMaster) : RemotePluginCl
     }
     else if (child == 0)
     {
-#ifdef VST6432
-#ifdef TRACKTIONWM 
-        if (dlltype == 2)
-        {
-            m_386run = 1;
-            #ifdef EMBED
-            if (execlp("/usr/bin/lin-vst-servertrack32.exe", "/usr/bin/lin-vst-servertrack32.exe", argStr, NULL))
-            #else
-            if (execlp("/usr/bin/lin-vst-servertrack32st.exe", "/usr/bin/lin-vst-servertrack32st.exe", argStr, NULL))
-            #endif
-            {
-                m_runok = 1;
-                cleanup();
-                return;
-            }
-        }
-        else
-        {
-            #ifdef EMBED
-            if (execlp("/usr/bin/lin-vst-servertrack.exe", "/usr/bin/lin-vst-servertrack.exe", argStr, NULL))
-            #else
-            if (execlp("/usr/bin/lin-vst-servertrackst.exe", "/usr/bin/lin-vst-servertrackst.exe", argStr, NULL))
-            #endif
-            {
-                m_runok = 1;
-                cleanup();
-                return;
-            }
-        }
-#else
-        if (dlltype == 2)
-        {
-            m_386run = 1;
-            #ifdef EMBED
-            if (execlp("/usr/bin/lin-vst-server32.exe", "/usr/bin/lin-vst-server32.exe", argStr, NULL))
-            #else
-            if (execlp("/usr/bin/lin-vst-server32st.exe", "/usr/bin/lin-vst-server32st.exe", argStr, NULL))
-            #endif
-            {
-                m_runok = 1;
-                cleanup();
-                return;
-            }
-        }
-        else
-        {
-            #ifdef EMBED
-            if (execlp("/usr/bin/lin-vst-server.exe", "/usr/bin/lin-vst-server.exe", argStr, NULL))
-            #else
-            if (execlp("/usr/bin/lin-vst-serverst.exe", "/usr/bin/lin-vst-serverst.exe", argStr, NULL))
-            #endif
-            {
-                m_runok = 1;
-                cleanup();
-                return;
-            }
-        }
-#endif
-#else
-#ifdef TRACKTIONWM 
-            #ifdef EMBED
-            if (execlp("/usr/bin/lin-vst-servertrack.exe", "/usr/bin/lin-vst-servertrack.exe", argStr, NULL))
-            #else
-            if (execlp("/usr/bin/lin-vst-servertrackst.exe", "/usr/bin/lin-vst-servertrackst.exe", argStr, NULL))
-            #endif
-        {
-            m_runok = 1;
-            cleanup();
-            return;
-        }            
-#else
-            #ifdef EMBED
-            if (execlp("/usr/bin/lin-vst-server.exe", "/usr/bin/lin-vst-server.exe", argStr, NULL))
-            #else
-            if (execlp("/usr/bin/lin-vst-serverst.exe", "/usr/bin/lin-vst-serverst.exe", argStr, NULL))
-            #endif
-        {
-            m_runok = 1;
-            cleanup();
-            return;
-        }
-#endif
-#endif
-
-#ifdef VST32
-            #ifdef EMBED
-            if (execlp("/usr/bin/lin-vst-server32lx.exe", "/usr/bin/lin-vst-server32lx.exe", argStr, NULL))
-            #else
-            if (execlp("/usr/bin/lin-vst-server32lxst.exe", "/usr/bin/lin-vst-server32lxst.exe", argStr, NULL))
-            #endif
-        {
-            m_runok = 1;
-            cleanup();
-            return;
-        }
-#endif
+      m_386run = 1;
+      if (execlp(vstExePath.c_str(), vstExePath.c_str(), argStr, NULL)) {
+        m_runok = 1;
+        cleanup();
+        return;
+      }
    }
     syncStartup();
 }


### PR DESCRIPTION
As I commented in #112, I have started to refactor the code related to path search and generation in [`remotevstclient.cpp`](https://github.com/osxmidi/LinVst/blob/63a4fbe62d92be2d8fad8d0c98d390178147a3ec/remotevstclient.cpp#L219-L541). The idea is to reduce the use of macros to improve readability, code completion from IDEs, etc. Later, I will try to handle `execlp()` calls using enviromental variables in wine, but I wanted to separate both changes to ease reviewing and testing.

In this PR, I have added some functionality to `paths.h` to generate the paths. Right now, it will handle the generation based on the basename, a suffix and the extension. It will consider `#ifdef EMBED` to add `st` to the name of the file.

The parent directory is still hardcoded to `/usr/bin`, but extracted to that function. The idea is to continue developing this solution and insert the logic to read from enviromental variables (or other places) there.

I just partially tested this refactor, and since it has been very large, it would be nice to receive some feedback of the changes.